### PR TITLE
feature: Create a generic message receiver

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,70 @@
 # Core
 
 Provides all the base classes, interfaces and enums for implementing platforms, as well as a class to more easily manage multiple platforms.
+
+## Usage
+
+### Receiving Messages
+
+#### Registered receivers
+
+You can register to receive messages while your app is running.
+
+To do this, create a `MessageListener` and call `WatchPlatformManager.addMessageListener` to register the listener.
+The second is to create a class extending `MessageReceiver` and register 
+Note you should call `WatchPlatformManager.removeMessageListener` when you no longer need your message listener.
+
+Using this method would look something like this:
+
+```kotlin
+val messageListener = object : MessageListener {
+    override fun onMessageReceived(
+        sourceWatchId: UUID,
+        message: String,
+        data: ByteArray?
+    ) {
+        // Handle the received message here
+    }
+}
+
+// Add the message listener
+watchPlatformManager.addMessageListener(messageListener)
+
+// Remove the message listener when no longer needed
+watchPlatformManager.removeMessageListener(messageListener)
+```
+
+#### Manifest-declared receivers
+
+You can also register to receive messages via a manifest-declared broadcast receiver.
+
+To do this, create a class extending `MessageReceiver` and register it in your app manifest with an intent filter for the action `com.boswelja.watchconnection.messages.ACTION_MESSAGE_RECEIVED`.
+
+Your resulting class should look like this:
+```kotlin
+class WatchMessageReceiver : MessageReceiver() {
+    override suspend fun onMessageReceived(
+        sourceWatchId: UUID,
+        message: String,
+        data: ByteArray?
+    ) {
+        // Handle message here
+    }
+}
+```
+
+And in your manifest:
+```xml
+<manifest>
+    <application>
+        <receiver
+            android:name=".WatchMessageReceiver"
+            android:exported="false"> <!-- Specify exported=false here to follow best practices -->
+            <intent-filter>
+                <action android:name="com.boswelja.watchconnection.messages.ACTION_MESSAGE_RECEIVED" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>
+
+```

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 
 dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+    api("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0-alpha01")
 }
 
 // Bundle sources with binaries

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -28,7 +28,6 @@ android {
 
 dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-    api("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0-alpha01")
 }
 
 // Bundle sources with binaries

--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -2,6 +2,10 @@
 -keep class com.boswelja.watchconnection.core.Messages
 
 # Keep classes
--keep class com.boswelja.watchconnection.core.WatchPlatform
 -keep class com.boswelja.watchconnection.core.WatchPlatformManager
 -keep class com.boswelja.watchconnection.core.Watch
+-keep class com.boswelja.watchconnection.core.MessageReceiver
+
+# Keep interfaces
+-keep class com.boswelja.watchconnection.core.MessageListener
+-keep class com.boswelja.watchconnection.core.WatchPlatform

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageListener.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageListener.kt
@@ -1,0 +1,13 @@
+package com.boswelja.watchconnection.core
+
+import java.util.UUID
+
+interface MessageListener {
+    /**
+     * Called when a message is received by this callback.
+     * @param sourceWatchId The [UUID] of the source watch.
+     * @param message The message that was received.
+     * @param data The data sent with the message, or null if there was none.
+     */
+    fun onMessageReceived(sourceWatchId: UUID, message: String, data: ByteArray?)
+}

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageListener.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageListener.kt
@@ -2,6 +2,10 @@ package com.boswelja.watchconnection.core
 
 import java.util.UUID
 
+/**
+ * An interface for message listeners. Add listener with [WatchPlatformManager.addMessageListener],
+ * and remove with [WatchPlatformManager.removeMessageListener] when no longer needed.
+ */
 interface MessageListener {
     /**
      * Called when a message is received by this callback.

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageReceiver.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageReceiver.kt
@@ -28,7 +28,7 @@ abstract class MessageReceiver : BroadcastReceiver() {
         data: ByteArray?
     )
 
-    override fun onReceive(context: Context?, intent: Intent?) {
+    final override fun onReceive(context: Context?, intent: Intent?) {
         // Don't handle intent if it's not ACTION_MESSAGE_RECEIVED
         if (intent?.action != Messages.ACTION_MESSAGE_RECEIVED) return
 

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageReceiver.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageReceiver.kt
@@ -1,0 +1,56 @@
+package com.boswelja.watchconnection.core
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/**
+ * A [BroadcastReceiver] for receiving messages from watches of all supported platforms.
+ */
+abstract class MessageReceiver : BroadcastReceiver() {
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+
+    /**
+     * Called when a message has been received. While this is a suspendable function, the limits
+     * of [BroadcastReceiver.goAsync] still apply.
+     * @param sourceWatchId The [Watch.id] of the watch that sent the message.
+     * @param message The message that was received.
+     * @param data The data included with the message, or null if there was no data.
+     */
+    abstract suspend fun onMessageReceived(
+        sourceWatchId: UUID,
+        message: String,
+        data: ByteArray?
+    )
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        // Don't handle intent if it's not ACTION_MESSAGE_RECEIVED
+        if (intent?.action != Messages.ACTION_MESSAGE_RECEIVED) return
+
+        // Going async
+        val pendingResult = goAsync()
+        coroutineScope.launch {
+            // Collect data from intent
+            val watchId = UUID.fromString(intent.getStringExtra(WATCH_ID_EXTRA))
+            val message = intent.getStringExtra(MESSAGE_EXTRA)!!
+            val data = intent.getByteArrayExtra(DATA_EXTRA)
+
+            // Pass it on to user code
+            onMessageReceived(watchId, message, data)
+
+            // Let the BroadcastReceiver know we're done
+            pendingResult.finish()
+        }
+    }
+
+    companion object {
+        const val WATCH_ID_EXTRA = "watch_id"
+        const val MESSAGE_EXTRA = "message"
+        const val DATA_EXTRA = "data"
+    }
+}

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageReceiver.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/MessageReceiver.kt
@@ -36,9 +36,9 @@ abstract class MessageReceiver : BroadcastReceiver() {
         val pendingResult = goAsync()
         coroutineScope.launch {
             // Collect data from intent
-            val watchId = UUID.fromString(intent.getStringExtra(WATCH_ID_EXTRA))
-            val message = intent.getStringExtra(MESSAGE_EXTRA)!!
-            val data = intent.getByteArrayExtra(DATA_EXTRA)
+            val watchId = UUID.fromString(intent.getStringExtra(EXTRA_WATCH_ID))
+            val message = intent.getStringExtra(EXTRA_MESSAGE)!!
+            val data = intent.getByteArrayExtra(EXTRA_DATA)
 
             // Pass it on to user code
             onMessageReceived(watchId, message, data)
@@ -49,8 +49,8 @@ abstract class MessageReceiver : BroadcastReceiver() {
     }
 
     companion object {
-        const val WATCH_ID_EXTRA = "watch_id"
-        const val MESSAGE_EXTRA = "message"
-        const val DATA_EXTRA = "data"
+        const val EXTRA_WATCH_ID = "watch_id"
+        const val EXTRA_MESSAGE = "message"
+        const val EXTRA_DATA = "data"
     }
 }

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
@@ -1,16 +1,6 @@
 package com.boswelja.watchconnection.core
 
-import java.util.UUID
-
 object Messages {
-    interface Listener {
-
-        /**
-         * Called when a message is received by this callback.
-         * @param sourceWatchId The [UUID] of the source watch.
-         * @param message The message that was received.
-         * @param data The data sent with the message, or null if there was none.
-         */
-        fun onMessageReceived(sourceWatchId: UUID, message: String, data: ByteArray?)
-    }
+    const val ACTION_MESSAGE_RECEIVED =
+        "com.boswelja.watchconnection.messages.ACTION_MESSAGE_RECEIVED"
 }

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
@@ -1,6 +1,32 @@
 package com.boswelja.watchconnection.core
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import java.util.UUID
+import android.content.ComponentName
+
 object Messages {
     const val ACTION_MESSAGE_RECEIVED =
         "com.boswelja.watchconnection.messages.ACTION_MESSAGE_RECEIVED"
+
+    @SuppressLint("QueryPermissionsNeeded")
+    fun sendBroadcast(context: Context, watchId: UUID, message: String, data: ByteArray?) {
+        Intent(ACTION_MESSAGE_RECEIVED).apply {
+            putExtra(MessageReceiver.WATCH_ID_EXTRA, watchId.toString())
+            putExtra(MessageReceiver.MESSAGE_EXTRA, message)
+            if (data?.isNotEmpty() == true) putExtra(MessageReceiver.DATA_EXTRA, data)
+        }.also { intent ->
+            // Get all registered message receivers and send the intent to them. We can suppress
+            // query permission warning since we're only targeting the package this lib is in.
+            context.packageManager.queryBroadcastReceivers(intent, 0).forEach { info ->
+                val component = ComponentName(
+                    info.activityInfo.packageName,
+                    info.activityInfo.name
+                )
+                intent.component = component
+                context.sendBroadcast(intent)
+            }
+        }
+    }
 }

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
@@ -7,9 +7,22 @@ import java.util.UUID
 import android.content.ComponentName
 
 object Messages {
+
+    /**
+     * Sent when a message is received from any supported [WatchPlatform]. Implement
+     * [MessageReceiver] to receive this intent.
+     */
     const val ACTION_MESSAGE_RECEIVED =
         "com.boswelja.watchconnection.messages.ACTION_MESSAGE_RECEIVED"
 
+    /**
+     * Build and send [ACTION_MESSAGE_RECEIVED] broadcast to all manifest receivers. This should not
+     * be called from application code, and is only exposed for [WatchPlatform] use.
+     * @param context [Context].
+     * @param watchId The ID of the watch that sent the message. See [Watch.id].
+     * @param message The message received.
+     * @param data The data sent with the message, or null if there was no data.
+     */
     @SuppressLint("QueryPermissionsNeeded")
     fun sendBroadcast(context: Context, watchId: UUID, message: String, data: ByteArray?) {
         Intent(ACTION_MESSAGE_RECEIVED).apply {

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
@@ -1,10 +1,10 @@
 package com.boswelja.watchconnection.core
 
 import android.annotation.SuppressLint
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import java.util.UUID
-import android.content.ComponentName
 
 object Messages {
 

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/Messages.kt
@@ -26,9 +26,9 @@ object Messages {
     @SuppressLint("QueryPermissionsNeeded")
     fun sendBroadcast(context: Context, watchId: UUID, message: String, data: ByteArray?) {
         Intent(ACTION_MESSAGE_RECEIVED).apply {
-            putExtra(MessageReceiver.WATCH_ID_EXTRA, watchId.toString())
-            putExtra(MessageReceiver.MESSAGE_EXTRA, message)
-            if (data?.isNotEmpty() == true) putExtra(MessageReceiver.DATA_EXTRA, data)
+            putExtra(MessageReceiver.EXTRA_WATCH_ID, watchId.toString())
+            putExtra(MessageReceiver.EXTRA_MESSAGE, message)
+            if (data?.isNotEmpty() == true) putExtra(MessageReceiver.EXTRA_DATA, data)
         }.also { intent ->
             // Get all registered message receivers and send the intent to them. We can suppress
             // query permission warning since we're only targeting the package this lib is in.

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/WatchPlatform.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/WatchPlatform.kt
@@ -45,15 +45,15 @@ interface WatchPlatform {
     ): Boolean
 
     /**
-     * Adds a new [Messages.Listener].
-     * @param listener The [Messages.Listener] to register.
+     * Adds a new [MessageListener].
+     * @param listener The [MessageListener] to register.
      */
-    fun addMessageListener(listener: Messages.Listener)
+    fun addMessageListener(listener: MessageListener)
 
     /**
-     * Removes a [Messages.Listener]. This will do nothing if the provided listener is not
+     * Removes a [MessageListener]. This will do nothing if the provided listener is not
      * registered.
-     * @param listener The [Messages.Listener] to unregister.
+     * @param listener The [MessageListener] to unregister.
      */
-    fun removeMessageListener(listener: Messages.Listener)
+    fun removeMessageListener(listener: MessageListener)
 }

--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/WatchPlatformManager.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/WatchPlatformManager.kt
@@ -56,18 +56,18 @@ class WatchPlatformManager(
     }
 
     /**
-     * Adds a [Messages.Listener] to all platforms.
+     * Adds a [MessageListener] to all platforms.
      */
-    fun addMessageListener(messageListener: Messages.Listener) {
+    fun addMessageListener(messageListener: MessageListener) {
         connectionHandlers.values.forEach {
             it.addMessageListener(messageListener)
         }
     }
 
     /**
-     * Removes a [Messages.Listener] from all platforms.
+     * Removes a [MessageListener] from all platforms.
      */
-    fun removeMessageListener(messageListener: Messages.Listener) {
+    fun removeMessageListener(messageListener: MessageListener) {
         connectionHandlers.values.forEach {
             it.removeMessageListener(messageListener)
         }

--- a/test/src/test/kotlin/com/boswelja/watchconnection/core/ConcreteMessageReceiver.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/core/ConcreteMessageReceiver.kt
@@ -1,0 +1,12 @@
+package com.boswelja.watchconnection.core
+
+import java.util.UUID
+
+class ConcreteMessageReceiver : MessageReceiver() {
+
+    override suspend fun onMessageReceived(
+        sourceWatchId: UUID,
+        message: String,
+        data: ByteArray?
+    ) { }
+}

--- a/test/src/test/kotlin/com/boswelja/watchconnection/core/DummyPlatform.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/core/DummyPlatform.kt
@@ -21,11 +21,11 @@ class DummyPlatform(
         return false
     }
 
-    override fun addMessageListener(listener: Messages.Listener) {
+    override fun addMessageListener(listener: MessageListener) {
         // Do nothing
     }
 
-    override fun removeMessageListener(listener: Messages.Listener) {
+    override fun removeMessageListener(listener: MessageListener) {
         // Do nothing
     }
 }

--- a/test/src/test/kotlin/com/boswelja/watchconnection/core/MessageReceiverTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/core/MessageReceiverTest.kt
@@ -1,0 +1,79 @@
+package com.boswelja.watchconnection.core
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.boswelja.watchconnection.core.MessageReceiver.Companion.EXTRA_DATA
+import com.boswelja.watchconnection.core.MessageReceiver.Companion.EXTRA_MESSAGE
+import com.boswelja.watchconnection.core.MessageReceiver.Companion.EXTRA_WATCH_ID
+import com.boswelja.watchconnection.core.Messages.ACTION_MESSAGE_RECEIVED
+import io.mockk.coVerify
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.UUID
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class MessageReceiverTest {
+
+    @get:Rule
+    val taskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var context: Context
+    private lateinit var messageReceiver: MessageReceiver
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        messageReceiver = spyk(ConcreteMessageReceiver())
+    }
+
+    @Test
+    fun `onReceive does nothing for incorrect actions`() {
+        val intent = Intent("action")
+        messageReceiver.onReceive(context, intent)
+        verify(inverse = true) { messageReceiver.goAsync() }
+        coVerify(inverse = true) { messageReceiver.onMessageReceived(any(), any(), any()) }
+    }
+
+    @Test
+    fun `onReceive passes variables to onMessageReceived if message has no data`() {
+        val id = UUID.randomUUID()
+        val message = "message"
+
+        Intent(ACTION_MESSAGE_RECEIVED).apply {
+            putExtra(EXTRA_WATCH_ID, id.toString())
+            putExtra(EXTRA_MESSAGE, message)
+        }.also { intent ->
+            messageReceiver.onReceive(context, intent)
+        }
+
+        coVerify { messageReceiver.onMessageReceived(id, message, null) }
+    }
+
+    @Test
+    fun `onReceive passes variables to onMessageReceived if message has data`() {
+        val id = UUID.randomUUID()
+        val message = "message"
+        val data = Random.nextBytes(10)
+
+        Intent(ACTION_MESSAGE_RECEIVED).apply {
+            putExtra(EXTRA_WATCH_ID, id.toString())
+            putExtra(EXTRA_MESSAGE, message)
+            putExtra(EXTRA_DATA, data)
+        }.also { intent ->
+            messageReceiver.onReceive(context, intent)
+        }
+
+        coVerify { messageReceiver.onMessageReceived(id, message, data) }
+    }
+}

--- a/test/src/test/kotlin/com/boswelja/watchconnection/core/WatchPlatformManagerTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/core/WatchPlatformManagerTest.kt
@@ -105,7 +105,7 @@ class WatchPlatformManagerTest {
 
     @Test
     fun `registerMessageListener adds the message listener to all platforms`() {
-        val messageListener = object : Messages.Listener {
+        val messageListener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,
@@ -120,7 +120,7 @@ class WatchPlatformManagerTest {
 
     @Test
     fun `unregisterMessageListener removes the message listener from all platforms`() {
-        val messageListener = object : Messages.Listener {
+        val messageListener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,

--- a/test/src/test/kotlin/com/boswelja/watchconnection/tizen/TizenPlatformTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/tizen/TizenPlatformTest.kt
@@ -4,7 +4,7 @@ import android.os.Build
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.boswelja.watchconnection.core.Messages
+import com.boswelja.watchconnection.core.MessageListener
 import com.samsung.android.sdk.accessory.SAAgentV2
 import io.mockk.MockKAnnotations
 import io.mockk.coVerify
@@ -129,7 +129,7 @@ class TizenPlatformTest {
 
     @Test
     fun `registerMessageListener calls agent`() {
-        val listener = object : Messages.Listener {
+        val listener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,
@@ -142,7 +142,7 @@ class TizenPlatformTest {
 
     @Test
     fun `unregisterMessageListener calls agent`() {
-        val listener = object : Messages.Listener {
+        val listener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,

--- a/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSPlatformTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSPlatformTest.kt
@@ -2,7 +2,7 @@ package com.boswelja.watchconnection.wearos
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.boswelja.watchconnection.core.Messages
+import com.boswelja.watchconnection.core.MessageListener
 import com.boswelja.watchconnection.wearos.CapabilityHelpers.createCapabilities
 import com.boswelja.watchconnection.wearos.NodeHelpers.createDummyNodes
 import com.google.android.gms.common.api.ApiException
@@ -147,13 +147,12 @@ class WearOSPlatformTest {
     @Test
     fun `registerMessageListener registers a listener with messageClient`() {
         // Create dummy listener
-        val listener = object : Messages.Listener {
+        val listener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,
                 data: ByteArray?
-            ) {
-            }
+            ) { }
         }
 
         // Register listener
@@ -166,13 +165,12 @@ class WearOSPlatformTest {
     @Test
     fun `unregisterMessageListener removes a listener with messageClient`() {
         // Create dummy listener
-        val listener = object : Messages.Listener {
+        val listener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,
                 data: ByteArray?
-            ) {
-            }
+            ) { }
         }
 
         // We need to add a listener first
@@ -188,13 +186,12 @@ class WearOSPlatformTest {
     @Test
     fun `unregisterMessageListener does nothing with previously unregistered listener`() {
         // Create dummy listener
-        val listener = object : Messages.Listener {
+        val listener = object : MessageListener {
             override fun onMessageReceived(
                 sourceWatchId: UUID,
                 message: String,
                 data: ByteArray?
-            ) {
-            }
+            ) { }
         }
 
         // Register listener

--- a/tizen/proguard-rules.pro
+++ b/tizen/proguard-rules.pro
@@ -1,5 +1,11 @@
 # Keep classes
 -keep class com.boswelja.watchconnection.tizen.TizenPlatform
+-keep class com.boswelja.watchconnection.tizen.TizenAccessoryAgent
+
+# Keep objects
+-keep class com.boswelja.watchconnection.tizen.Messages
+
+# Keep Samsung Accessory SDK
 -keepclassmembers class com.samsung.** { *;}
 -keep class com.samsung.** { *; }
 -dontwarn com.samsung.**

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/Messages.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/Messages.kt
@@ -1,0 +1,35 @@
+package com.boswelja.watchconnection.tizen
+
+object Messages {
+    private const val messageDelimiter = '|'.toByte()
+
+    fun toByteArray(message: String, data: ByteArray?): ByteArray {
+        var messageData = message.toByteArray(Charsets.UTF_8)
+        // If data is not null, add delimiter and data to message
+        data?.let {
+            messageData += messageDelimiter
+            messageData += data
+        }
+        return messageData
+    }
+
+    fun fromByteArray(data: ByteArray): Pair<String, ByteArray?> {
+        val delimiterIndex = data.indexOfFirst { it == messageDelimiter }
+        return when {
+            delimiterIndex <= -1 -> {
+                // If delimiterIndex is -1, then we have no data
+                Pair(String(data, Charsets.UTF_8), null)
+            }
+            delimiterIndex <= 0 -> {
+                // If delimiter index is 0, we've got an invalid message
+                throw IllegalArgumentException("Couldn't parse message identifier from data")
+            }
+            else -> {
+                // In all other conditions, we have data
+                val message = data.copyOfRange(0, delimiterIndex)
+                val messageData = data.copyOfRange(delimiterIndex + 1, data.size)
+                Pair(String(message, Charsets.UTF_8), messageData)
+            }
+        }
+    }
+}

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/Messages.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/Messages.kt
@@ -3,7 +3,10 @@ package com.boswelja.watchconnection.tizen
 object Messages {
     private const val messageDelimiter = '|'.toByte()
 
-    fun toByteArray(message: String, data: ByteArray?): ByteArray {
+    /**
+     * Convert a message to a [ByteArray] for use with [TizenAccessoryAgent].
+     */
+    internal fun toByteArray(message: String, data: ByteArray?): ByteArray {
         var messageData = message.toByteArray(Charsets.UTF_8)
         // If data is not null, add delimiter and data to message
         data?.let {
@@ -13,7 +16,10 @@ object Messages {
         return messageData
     }
 
-    fun fromByteArray(data: ByteArray): Pair<String, ByteArray?> {
+    /**
+     * Get a message from a [ByteArray] for use with [TizenAccessoryAgent].
+     */
+    internal fun fromByteArray(data: ByteArray): Pair<String, ByteArray?> {
         val delimiterIndex = data.indexOfFirst { it == messageDelimiter }
         return when {
             delimiterIndex <= -1 -> {

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
@@ -142,6 +142,11 @@ class TizenAccessoryAgent internal constructor(
         }
     }
 
+    /**
+     * Handle a [TizenPlatform.CAPABILITY_MESSAGE].
+     * @param peer The [SAPeerAgent] that sent the capability data.
+     * @param data The received capability data.
+     */
     private fun handleCapabilityMessage(peer: SAPeerAgent, data: ByteArray) {
         coroutineScope.launch(Dispatchers.IO + capabilityJob) {
             capabilityMap[peer.accessory.accessoryId]?.let { flow ->
@@ -152,6 +157,12 @@ class TizenAccessoryAgent internal constructor(
         }
     }
 
+    /**
+     * Pass a received message on to message listeners and broadcast receivers.
+     * @param peer The [SAPeerAgent] that sent the message.
+     * @param message The message received.
+     * @param data The data received with the message, or null if there was none.
+     */
     private fun handleMessage(peer: SAPeerAgent, message: String, data: ByteArray?) {
         val id = Watch.createUUID(
             TizenPlatform.PLATFORM,

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
@@ -1,7 +1,7 @@
 package com.boswelja.watchconnection.tizen
 
 import android.content.Context
-import com.boswelja.watchconnection.core.Messages
+import com.boswelja.watchconnection.core.MessageListener
 import com.boswelja.watchconnection.core.Watch
 import com.samsung.android.sdk.SsdkUnsupportedException
 import com.samsung.android.sdk.accessory.SA
@@ -33,7 +33,7 @@ class TizenAccessoryAgent internal constructor(
     private val allWatches = MutableStateFlow<Watch?>(null)
 
     private val peerMap = HashMap<String, SAPeerAgent>()
-    private val messageListeners = ArrayList<Messages.Listener>()
+    private val messageListeners = ArrayList<MessageListener>()
 
     // Keep a map of channels to message IDs to
     private val messageChannelMap = HashMap<Int, Channel<Boolean>>()
@@ -149,11 +149,11 @@ class TizenAccessoryAgent internal constructor(
         return withTimeoutOrNull(OPERATION_TIMEOUT) { channel.receiveOrNull() } == true
     }
 
-    fun registerMessageListener(listener: Messages.Listener) {
+    fun registerMessageListener(listener: MessageListener) {
         messageListeners.add(listener)
     }
 
-    fun unregisterMessageListener(listener: Messages.Listener) {
+    fun unregisterMessageListener(listener: MessageListener) {
         messageListeners.remove(listener)
     }
 

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
@@ -1,11 +1,8 @@
 package com.boswelja.watchconnection.tizen
 
 import android.content.Context
-import android.content.Intent
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.boswelja.watchconnection.core.MessageListener
-import com.boswelja.watchconnection.core.MessageReceiver
-import com.boswelja.watchconnection.core.Messages.ACTION_MESSAGE_RECEIVED
+import com.boswelja.watchconnection.core.Messages.sendBroadcast
 import com.boswelja.watchconnection.core.Watch
 import com.samsung.android.sdk.SsdkUnsupportedException
 import com.samsung.android.sdk.accessory.SA
@@ -168,15 +165,8 @@ class TizenAccessoryAgent internal constructor(
             )
         }
 
-        // Broadcast intent for user receivers
-        Intent(ACTION_MESSAGE_RECEIVED).apply {
-            putExtra(MessageReceiver.WATCH_ID_EXTRA, id.toString())
-            putExtra(MessageReceiver.MESSAGE_EXTRA, message)
-            if (data?.isNotEmpty() == true) putExtra(MessageReceiver.DATA_EXTRA, data)
-        }.also {
-            // Send to receivers in this app specifically
-            LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(it)
-        }
+        // Send message broadcast
+        sendBroadcast(applicationContext, id, message, data)
     }
 
     companion object {

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenAccessoryAgent.kt
@@ -1,7 +1,11 @@
 package com.boswelja.watchconnection.tizen
 
 import android.content.Context
+import android.content.Intent
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.boswelja.watchconnection.core.MessageListener
+import com.boswelja.watchconnection.core.MessageReceiver
+import com.boswelja.watchconnection.core.Messages.ACTION_MESSAGE_RECEIVED
 import com.boswelja.watchconnection.core.Watch
 import com.samsung.android.sdk.SsdkUnsupportedException
 import com.samsung.android.sdk.accessory.SA
@@ -162,6 +166,16 @@ class TizenAccessoryAgent internal constructor(
                 message,
                 data
             )
+        }
+
+        // Broadcast intent for user receivers
+        Intent(ACTION_MESSAGE_RECEIVED).apply {
+            putExtra(MessageReceiver.WATCH_ID_EXTRA, id.toString())
+            putExtra(MessageReceiver.MESSAGE_EXTRA, message)
+            if (data?.isNotEmpty() == true) putExtra(MessageReceiver.DATA_EXTRA, data)
+        }.also {
+            // Send to receivers in this app specifically
+            LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(it)
         }
     }
 

--- a/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenPlatform.kt
+++ b/tizen/src/main/kotlin/com/boswelja/watchconnection/tizen/TizenPlatform.kt
@@ -1,7 +1,7 @@
 package com.boswelja.watchconnection.tizen
 
 import android.content.Context
-import com.boswelja.watchconnection.core.Messages
+import com.boswelja.watchconnection.core.MessageListener
 import com.boswelja.watchconnection.core.Watch
 import com.boswelja.watchconnection.core.WatchPlatform
 import com.samsung.android.sdk.accessory.SAAgentV2
@@ -58,10 +58,10 @@ class TizenPlatform(
     override suspend fun sendMessage(watchId: String, message: String, data: ByteArray?): Boolean =
         accessoryAgent.sendMessage(watchId, message, data)
 
-    override fun addMessageListener(listener: Messages.Listener) =
+    override fun addMessageListener(listener: MessageListener) =
         accessoryAgent.registerMessageListener(listener)
 
-    override fun removeMessageListener(listener: Messages.Listener) =
+    override fun removeMessageListener(listener: MessageListener) =
         accessoryAgent.unregisterMessageListener(listener)
 
     companion object {

--- a/wearos/proguard-rules.pro
+++ b/wearos/proguard-rules.pro
@@ -1,2 +1,3 @@
 # Keep classes
 -keep class com.boswelja.watchconnection.wearos.WearOSPlatform
+-keep class com.boswelja.watchconnection.wearos.WearOSMessageReceiver

--- a/wearos/src/main/AndroidManifest.xml
+++ b/wearos/src/main/AndroidManifest.xml
@@ -1,1 +1,16 @@
-<manifest package="com.boswelja.watchconnection.wearos" />
+<manifest
+    package="com.boswelja.watchconnection.wearos"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <service
+            android:name="com.boswelja.watchconnection.wearos.WearOSMessageReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.MESSAGE_RECEIVED" />
+                <data
+                    android:host="*"
+                    android:scheme="wear" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSMessageReceiver.kt
+++ b/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSMessageReceiver.kt
@@ -1,0 +1,32 @@
+package com.boswelja.watchconnection.wearos
+
+import android.content.Intent
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.boswelja.watchconnection.core.MessageReceiver
+import com.boswelja.watchconnection.core.Messages
+import com.boswelja.watchconnection.core.Watch
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.WearableListenerService
+
+/**
+ * A [WearableListenerService] to parse [MessageEvent]s and hand them off to
+ * [Messages.ACTION_MESSAGE_RECEIVED] receivers.
+ */
+class WearOSMessageReceiver : WearableListenerService() {
+    override fun onMessageReceived(messageEvent: MessageEvent?) {
+        messageEvent?.let { event ->
+            // Get watch ID
+            val watchId = Watch.createUUID(WearOSPlatform.PLATFORM, event.sourceNodeId)
+
+            // Build intent
+            Intent(Messages.ACTION_MESSAGE_RECEIVED).apply {
+                putExtra(MessageReceiver.WATCH_ID_EXTRA, watchId.toString())
+                putExtra(MessageReceiver.MESSAGE_EXTRA, event.path)
+                if (event.data.isNotEmpty()) putExtra(MessageReceiver.DATA_EXTRA, event.data)
+            }.also {
+                // Send to receivers in this app specifically
+                LocalBroadcastManager.getInstance(this).sendBroadcast(it)
+            }
+        }
+    }
+}

--- a/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSMessageReceiver.kt
+++ b/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSMessageReceiver.kt
@@ -1,8 +1,5 @@
 package com.boswelja.watchconnection.wearos
 
-import android.content.Intent
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import com.boswelja.watchconnection.core.MessageReceiver
 import com.boswelja.watchconnection.core.Messages
 import com.boswelja.watchconnection.core.Watch
 import com.google.android.gms.wearable.MessageEvent
@@ -18,15 +15,8 @@ class WearOSMessageReceiver : WearableListenerService() {
             // Get watch ID
             val watchId = Watch.createUUID(WearOSPlatform.PLATFORM, event.sourceNodeId)
 
-            // Build intent
-            Intent(Messages.ACTION_MESSAGE_RECEIVED).apply {
-                putExtra(MessageReceiver.WATCH_ID_EXTRA, watchId.toString())
-                putExtra(MessageReceiver.MESSAGE_EXTRA, event.path)
-                if (event.data.isNotEmpty()) putExtra(MessageReceiver.DATA_EXTRA, event.data)
-            }.also {
-                // Send to receivers in this app specifically
-                LocalBroadcastManager.getInstance(this).sendBroadcast(it)
-            }
+            // Send message broadcast
+            Messages.sendBroadcast(this, watchId, event.path, event.data)
         }
     }
 }

--- a/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSPlatform.kt
+++ b/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSPlatform.kt
@@ -1,7 +1,7 @@
 package com.boswelja.watchconnection.wearos
 
 import android.content.Context
-import com.boswelja.watchconnection.core.Messages
+import com.boswelja.watchconnection.core.MessageListener
 import com.boswelja.watchconnection.core.Watch
 import com.boswelja.watchconnection.core.WatchPlatform
 import com.google.android.gms.common.api.ApiException
@@ -41,7 +41,7 @@ class WearOSPlatform constructor(
     )
 
     private val messageListeners =
-        mutableMapOf<Messages.Listener, MessageClient.OnMessageReceivedListener>()
+        mutableMapOf<MessageListener, MessageClient.OnMessageReceivedListener>()
 
     override val platformIdentifier = PLATFORM
 
@@ -93,7 +93,7 @@ class WearOSPlatform constructor(
         }
     }
 
-    override fun addMessageListener(listener: Messages.Listener) {
+    override fun addMessageListener(listener: MessageListener) {
         val onMessageReceiveListener = MessageClient.OnMessageReceivedListener {
             val id = Watch.createUUID(PLATFORM, it.sourceNodeId)
             listener.onMessageReceived(id, it.path, it.data)
@@ -103,7 +103,7 @@ class WearOSPlatform constructor(
         messageListeners[listener] = onMessageReceiveListener
     }
 
-    override fun removeMessageListener(listener: Messages.Listener) {
+    override fun removeMessageListener(listener: MessageListener) {
         // Look up listener and remove it from both the map and messageClient
         messageListeners.remove(listener)?.let {
             messageClient.removeListener(it)


### PR DESCRIPTION
Resolves #16 
Users can override `MessageReceiver` and declare the receiver in the manifest to receive messages from all platforms in one place.