### PR TITLE
feature: Add support for detecting whether a watch is nearby on supported platforms

### DIFF
--- a/core/src/main/kotlin/com/boswelja/watchconnection/core/discovery/Status.kt
+++ b/core/src/main/kotlin/com/boswelja/watchconnection/core/discovery/Status.kt
@@ -3,6 +3,7 @@ package com.boswelja.watchconnection.core.discovery
 enum class Status {
     CONNECTING,
     CONNECTED,
+    CONNECTED_NEARBY,
     DISCONNECTED,
     MISSING_APP,
     ERROR

--- a/test/src/test/kotlin/com/boswelja/watchconnection/TestHelpers.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/TestHelpers.kt
@@ -5,7 +5,7 @@ import com.boswelja.watchconnection.core.message.Message
 import kotlin.random.Random
 
 fun createWatchesFor(count: Int, platformIdentifier: String): List<Watch> {
-    return (0..count).map {
+    return (0 until count).map {
         Watch(
             name = "Watch $it",
             "platform$count",
@@ -15,7 +15,7 @@ fun createWatchesFor(count: Int, platformIdentifier: String): List<Watch> {
 }
 
 fun createCapabilities(count: Int): List<String> {
-    return (0..count).map { "capability$it" }
+    return (0 until count).map { "capability$it" }
 }
 
 /**
@@ -23,7 +23,7 @@ fun createCapabilities(count: Int): List<String> {
  * assigned by WatchConnectionLib), and a fake [Message].
  */
 fun createMessagesFor(count: Int, platform: String): List<Pair<String, Message>> {
-    return (0..count).map {
+    return (0 until count).map {
         Pair(
             it.toString(),
             Message(

--- a/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSDiscoveryPlatformTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSDiscoveryPlatformTest.kt
@@ -1,7 +1,5 @@
 package com.boswelja.watchconnection.wearos
 
-import android.os.Build
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.boswelja.watchconnection.wearos.rules.CapabilityClientTestRule
 import com.boswelja.watchconnection.wearos.rules.NodeClientTestRule
 import com.boswelja.watchconnection.wearos.rules.createNodes
@@ -13,14 +11,10 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
 import strikt.assertions.isNotNull
 
-@RunWith(AndroidJUnit4::class)
-@Config(sdk = [Build.VERSION_CODES.R])
 class WearOSDiscoveryPlatformTest {
 
     private val appCapability = "app-capability"

--- a/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSMessagePlatformTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSMessagePlatformTest.kt
@@ -94,7 +94,7 @@ class WearOSMessagePlatformTest {
         }
 
         // TODO This could cause flaky tests, remove it
-        Thread.sleep(50)
+        Thread.sleep(250)
 
         // Send the dummy messages
         messages.forEach {

--- a/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSMessagePlatformTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSMessagePlatformTest.kt
@@ -1,7 +1,5 @@
 package com.boswelja.watchconnection.wearos
 
-import android.os.Build
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.boswelja.watchconnection.core.message.Message
 import com.boswelja.watchconnection.createMessagesFor
 import com.boswelja.watchconnection.wearos.rules.MessageClientTestRule
@@ -17,13 +15,9 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
 
-@RunWith(AndroidJUnit4::class)
-@Config(sdk = [Build.VERSION_CODES.R])
 class WearOSMessagePlatformTest {
 
     @get:Rule

--- a/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSMessagePlatformTest.kt
+++ b/test/src/test/kotlin/com/boswelja/watchconnection/wearos/WearOSMessagePlatformTest.kt
@@ -87,9 +87,6 @@ class WearOSMessagePlatformTest {
             }
         }
 
-        // TODO This could cause flaky tests, remove it
-        Thread.sleep(250)
-
         // Send the dummy messages
         messages.forEach {
             messageClientTestRule.receiveMessage(

--- a/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSDiscoveryPlatform.kt
+++ b/wearos/src/main/kotlin/com/boswelja/watchconnection/wearos/WearOSDiscoveryPlatform.kt
@@ -135,8 +135,12 @@ class WearOSDiscoveryPlatform(
                 // runBlocking should be safe here, since we're within a Flow
                 val connectedNodes = runBlocking { nodeClient.connectedNodes.await() }
                 // Got connected nodes, check if it contains our desired node
-                if (connectedNodes.any { it.id == watchId }) trySend(Status.CONNECTED)
-                else trySend(Status.DISCONNECTED)
+                val node = connectedNodes.firstOrNull { it.id == watchId }
+                val status = node?.let {
+                    if (node.isNearby) Status.CONNECTED_NEARBY
+                    else Status.CONNECTED
+                } ?: Status.DISCONNECTED
+                trySend(status)
             } catch (e: CancellationException) {
                 // Failed, send error
                 trySend(Status.ERROR)


### PR DESCRIPTION
Wear OS watches can remain connected over the internet, and the API allows us to check whether the node is nearby or not. I've added a new status, CONNECTED_NEARBY to indicate the device is nearby.